### PR TITLE
Switch to jline-native

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - query the terminal size, and
 - on Windows, change the console mode so that it accepts ANSI escape codes.
 
-It relies on internals of the [jansi](https://github.com/fusesource/jansi) library to do so, and also works from
+It relies on internals of the [jline-native](https://github.com/jline/jline3/tree/master/native) library to do so, and also works from
 GraalVM native images.
 
 Compared to using [jline](https://github.com/jline/jline3), *native-terminal* only and solely calls the right

--- a/build.sc
+++ b/build.sc
@@ -98,7 +98,7 @@ object native extends JavaModule with WindowsAnsiPublishModule {
   def artifactName = "native-terminal"
   def ivyDeps = Agg(
     ivy"io.github.alexarchambault:is-terminal:0.1.2",
-    ivy"org.fusesource.jansi:jansi:2.4.1"
+    ivy"org.jline:jline-native:3.29.0"
   )
 }
 

--- a/native-graalvm/src/io/github/alexarchambault/windowsansi/NativeImageFeature.java
+++ b/native-graalvm/src/io/github/alexarchambault/windowsansi/NativeImageFeature.java
@@ -52,21 +52,21 @@ final class NativeImageFeature implements Feature {
 
     /** List of the classes that access the JNI library. */
     private static final List<String> JNI_CLASS_NAMES = Arrays.asList(
-            "org.fusesource.jansi.internal.CLibrary",
-            "org.fusesource.jansi.internal.CLibrary$WinSize",
-            "org.fusesource.jansi.internal.CLibrary$Termios");
+            "org.jline.nativ.CLibrary",
+            "org.jline.nativ.CLibrary$WinSize",
+            "org.jline.nativ.CLibrary$Termios");
     private static final List<String> WINDOWS_JNI_CLASS_NAMES = Arrays.asList(
-            "org.fusesource.jansi.internal.Kernel32",
-            "org.fusesource.jansi.internal.Kernel32$SMALL_RECT",
-            "org.fusesource.jansi.internal.Kernel32$COORD",
-            "org.fusesource.jansi.internal.Kernel32$CONSOLE_SCREEN_BUFFER_INFO",
-            "org.fusesource.jansi.internal.Kernel32$CHAR_INFO",
-            "org.fusesource.jansi.internal.Kernel32$KEY_EVENT_RECORD",
-            "org.fusesource.jansi.internal.Kernel32$MOUSE_EVENT_RECORD",
-            "org.fusesource.jansi.internal.Kernel32$WINDOW_BUFFER_SIZE_RECORD",
-            "org.fusesource.jansi.internal.Kernel32$FOCUS_EVENT_RECORD",
-            "org.fusesource.jansi.internal.Kernel32$MENU_EVENT_RECORD",
-            "org.fusesource.jansi.internal.Kernel32$INPUT_RECORD");
+            "org.jline.nativ.Kernel32",
+            "org.jline.nativ.Kernel32$SMALL_RECT",
+            "org.jline.nativ.Kernel32$COORD",
+            "org.jline.nativ.Kernel32$CONSOLE_SCREEN_BUFFER_INFO",
+            "org.jline.nativ.Kernel32$CHAR_INFO",
+            "org.jline.nativ.Kernel32$KEY_EVENT_RECORD",
+            "org.jline.nativ.Kernel32$MOUSE_EVENT_RECORD",
+            "org.jline.nativ.Kernel32$WINDOW_BUFFER_SIZE_RECORD",
+            "org.jline.nativ.Kernel32$FOCUS_EVENT_RECORD",
+            "org.jline.nativ.Kernel32$MENU_EVENT_RECORD",
+            "org.jline.nativ.Kernel32$INPUT_RECORD");
 
     @Override
     public void beforeAnalysis(BeforeAnalysisAccess access) {
@@ -101,21 +101,20 @@ final class NativeImageFeature implements Feature {
             /* The native library that is included as a resource in the .jar file. */
             String resource = null;
             if (Platform.includedIn(Platform.WINDOWS_AMD64.class))
-                resource = "Windows/x86_64/jansi.dll";
+                resource = "Windows/x86_64/jlinenative.dll";
             else if (Platform.includedIn(Platform.WINDOWS_AARCH64.class))
-                // FIXME File name should be changed to jansi.dll in the upcoming jansi version
-                resource = "Windows/arm64/libjansi.so";
+                resource = "Windows/arm64/jlinenative.dll";
             else if (Platform.includedIn(Platform.LINUX_AMD64.class))
-                resource = "Linux/x86_64/libjansi.so";
+                resource = "Linux/x86_64/libjlinenative.so";
             else if (Platform.includedIn(Platform.LINUX_AARCH64.class))
-                resource = "Linux/arm64/libjansi.so";
+                resource = "Linux/arm64/libjlinenative.so";
             else if (Platform.includedIn(Platform.DARWIN_AMD64.class))
-                resource = "Mac/x86_64/libjansi.jnilib";
+                resource = "Mac/x86_64/libjlinenative.jnilib";
             else if (Platform.includedIn(Platform.DARWIN_AARCH64.class))
-                resource = "Mac/arm64/libjansi.jnilib";
+                resource = "Mac/arm64/libjlinenative.jnilib";
 
             if (resource != null) {
-                resource = "org/fusesource/jansi/internal/native/" + resource;
+                resource = "org/jline/nativ/" + resource;
                 InputStream is = jniClass.getClassLoader().getResourceAsStream(resource);
                 if (is == null)
                     throw new RuntimeException("Could not find resource " + resource);

--- a/native/src/io/github/alexarchambault/nativeterm/NativeTerminal.java
+++ b/native/src/io/github/alexarchambault/nativeterm/NativeTerminal.java
@@ -24,7 +24,7 @@ public final class NativeTerminal {
      * Gets the terminal size
      *
      * This uses an {@code ioctl} call on Linux / Mac, and a {@code kernel32.dll} method
-     * on Windows. Both are done via JNI, using libraries that ship with jansi.
+     * on Windows. Both are done via JNI, using libraries that ship with jline-native.
      *
      * @return the terminal size
      */
@@ -41,7 +41,7 @@ public final class NativeTerminal {
      * returns true in that case.
      *
      * Under-the-hood, this calls a {@code kernel32.dll} method, via JNI,
-     * using libraries that ship with jansi.
+     * using libraries that ship with jline-native.
      *
      * @throws IOException if anything goes wrong
      * @return Whether ANSI output is enabled

--- a/native/src/io/github/alexarchambault/nativeterm/internal/UnixTerm.java
+++ b/native/src/io/github/alexarchambault/nativeterm/internal/UnixTerm.java
@@ -1,9 +1,9 @@
 package io.github.alexarchambault.nativeterm.internal;
 
 import io.github.alexarchambault.nativeterm.TerminalSize;
-import org.fusesource.jansi.internal.CLibrary;
+import org.jline.nativ.CLibrary;
 
-import static org.fusesource.jansi.internal.CLibrary.*;
+import static org.jline.nativ.CLibrary.*;
 
 /**
  * Utilities to get the terminal size on Linux / Mac
@@ -19,7 +19,7 @@ public final class UnixTerm {
      */
     public static TerminalSize getSize(boolean useStdout) {
         WinSize sz = new WinSize();
-        int fd = useStdout ? STDOUT_FILENO : STDERR_FILENO;
+        int fd = useStdout ? 1 : 2;
         ioctl(fd, CLibrary.TIOCGWINSZ, sz);
         return TerminalSize.of(sz.ws_col, sz.ws_row);
     }

--- a/native/src/io/github/alexarchambault/nativeterm/internal/WindowsTerm.java
+++ b/native/src/io/github/alexarchambault/nativeterm/internal/WindowsTerm.java
@@ -1,7 +1,7 @@
 package io.github.alexarchambault.nativeterm.internal;
 
 import io.github.alexarchambault.nativeterm.TerminalSize;
-import org.fusesource.jansi.internal.Kernel32;
+import org.jline.nativ.Kernel32;
 
 import java.io.IOException;
 import java.net.URL;
@@ -15,18 +15,8 @@ public final class WindowsTerm {
     private WindowsTerm() {}
 
     static {
-        // Workaround while we can't benefit from https://github.com/fusesource/jansi/pull/292
-        String arch = System.getProperty("os.arch", "").toLowerCase(Locale.ROOT);
-        if (arch.equals("arm64") || arch.equals("aarch64")) {
-            ClassLoader cl = Thread.currentThread().getContextClassLoader();
-            URL dllUrl = cl.getResource("org/fusesource/jansi/internal/native/Windows/arm64/jansi.dll");
-            URL soUrl = cl.getResource("org/fusesource/jansi/internal/native/Windows/arm64/libjansi.so");
-            if (dllUrl == null && soUrl != null) {
-                System.setProperty("library.jansi.name", "libjansi.so");
-            }
-        }
-
         // Make https://github.com/fusesource/hawtjni/blob/c14fec00b9976ff6b84e62e483d678594a7d3832/hawtjni-runtime/src/main/java/org/fusesource/hawtjni/runtime/Library.java#L167 happy
+        // Don't know if that's needed anymore with jline-native
         if (System.getProperty("com.ibm.vm.bitmode") == null)
             System.setProperty("com.ibm.vm.bitmode", "64");
     }


### PR DESCRIPTION
Seems jansi is meant to be replaced by jline, see https://github.com/fusesource/jansi/issues/294